### PR TITLE
Fixes duplicate declaration error if multiple codenames are used

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -62,7 +62,7 @@ define reprepro::repo (
     owner   => $www_user,
   }
   $codenames.each | $codename | {
-    cron { "sign incoming packages for ${title}":
+    cron { "sign incoming packages for ${title}-${codename}":
       ensure  => present,
       command => "for file in ${repofolder}/incoming/*; do /usr/bin/reprepro -b ${repofolder}/ includedeb ${codename} \$file; done \
       && /bin/chown -R ${www_user}:${www_group} ${repofolder}",


### PR DESCRIPTION
When using multiple codenames I got the following error:

Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: Cron[sign incoming packages for _<title>_] is already declared at (file: /etc/puppetlabs/code/environments/production/modules/reprepro/manifests/repo.pp, line: 65); cannot redeclare (file: /etc/puppetlabs/code/environments/production/modules/reprepro/manifests/repo.pp, line: 65) 

This commit should fix that.